### PR TITLE
Update webpack for compatibility with stable Node.js

### DIFF
--- a/minimal/Content/package.json
+++ b/minimal/Content/package.json
@@ -6,9 +6,9 @@
     "build": "dotnet fable src && webpack"
   },
   "devDependencies": {
-    "webpack": "^4.46.0",
-    "webpack-cli": "^3.3.0",
-    "webpack-dev-server": "^3.11.2"
+    "webpack": "^5.75.0",
+    "webpack-cli": "^4.10.0",
+    "webpack-dev-server": "^4.11.1"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
Hope that makes sense and the only update needed is in package.json

This fixes the issue here: https://github.com/fable-compiler/Fable/issues/3262

Please let me know if I need to do an `npm install` first and update also package-lock.json