### PR TITLE
Migrate webpack dev server config to v4

### DIFF
--- a/minimal/Content/webpack.config.js
+++ b/minimal/Content/webpack.config.js
@@ -25,8 +25,10 @@ module.exports = {
         filename: "bundle.js",
     },
     devServer: {
-        publicPath: "/",
-        contentBase: "./public",
+        static: {
+            directory: path.resolve(__dirname, "./public"),
+            publicPath: "/",
+        },
         port: 8080,
 //#if( gitpod )
         public: getDevServerUrl(),


### PR DESCRIPTION
This updates the webpack config according to https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md. The gitpod options are left untouched here but are out of date as well.

Fixes #74 