### PR TITLE
Update gitpod webpack dev

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,9 +1,0 @@
-FROM gitpod/workspace-full:latest
-
-USER root
-
-RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && rm -rf packages-microsoft-prod.deb && \
-    add-apt-repository universe && \
-    apt-get update && apt-get -y -o APT::Install-Suggests="true" install dotnet-sdk-3.1 && \
-    apt -y clean;

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,7 +27,4 @@ github:
 
 vscode:
   extensions:
-    - christian-kohler.path-intellisense@1.4.2:QnOrf5fk6KiVaQs4cNEP+w==
-    - wayou.vscode-todo-highlight@1.0.4:8IqxuxCVol2WnScJc5xVzg==
-    - mrmlnc.vscode-scss@0.9.0:/wXbNRm+2kunH5HbQqfnXA==
-    - Ionide.Ionide-fsharp@4.5.0:0qxXuhq6eO066etkNQrKCQ==
+    - Ionide.Ionide-fsharp

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,10 @@
-image:
-  file: .docker/Dockerfile
+image: gitpod/workspace-dotnet
 
 ports:
   - port: 8080
 
 tasks:
   - before: dotnet tool restore && dotnet restore
-  - init: ./fake.sh build -t BuildLib
 
 github:
   prebuilds:

--- a/minimal/Content/webpack.config.js
+++ b/minimal/Content/webpack.config.js
@@ -16,7 +16,11 @@ module.exports = {
             directory: path.resolve(__dirname, "./public"),
             publicPath: "/",
         },
-        port: 8080
+        port: 8080,
+//#if( gitpod )
+        host: '0.0.0.0',
+        allowedHosts: ['localhost', '.gitpod.io']
+//#endif
     },
     module: {
     }

--- a/minimal/Content/webpack.config.js
+++ b/minimal/Content/webpack.config.js
@@ -3,19 +3,6 @@
 // https://github.com/fable-compiler/webpack-config-template
 
 var path = require("path");
-//#if( gitpod )
-const execSync = require('child_process').execSync;
-var isGitPod = process.env.GITPOD_INSTANCE_ID !== undefined;
-
-function getDevServerUrl() {
-    if (isGitPod) {
-        const url = execSync('gp url 8080');
-        return url.toString().trim();
-    } else {
-        return `http://localhost:8080`;
-    }
-}
-//#endif
 
 module.exports = {
     mode: "development",
@@ -29,12 +16,7 @@ module.exports = {
             directory: path.resolve(__dirname, "./public"),
             publicPath: "/",
         },
-        port: 8080,
-//#if( gitpod )
-        public: getDevServerUrl(),
-        host: '0.0.0.0',
-        allowedHosts: ['localhost', '.gitpod.io']
-//#endif
+        port: 8080
     },
     module: {
     }

--- a/minimal/Content/webpack.config.js
+++ b/minimal/Content/webpack.config.js
@@ -25,8 +25,10 @@ module.exports = {
         filename: "bundle.js",
     },
     devServer: {
-        publicPath: "/",
-        contentBase: "./public",
+        static: {
+            directory: path.resolve(__dirname, "./public"),
+            publicPath: "/",
+        },
         port: 8080,
 //#if( gitpod )
         public: getDevServerUrl(),


### PR DESCRIPTION
Updates the gitpod config to use their provided dotnet image (currently dotnet 6) and removes a deprecated webpack option. This is built on #75. 